### PR TITLE
Properly deal with non-empty "Content-Transfer-Encoding"

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -81,7 +81,7 @@ function Multipart(boy, limits, headers, parsedConType) {
         return;
 
       if (header['content-transfer-encoding'])
-        encoding = header['content-transfer-encoding'].toLowerCase();
+        encoding = header['content-transfer-encoding'][0].toLowerCase();
       else
         encoding = '7bit';
 


### PR DESCRIPTION
`header['content-transfer-encoding']`   is  an   `Array`  &   cannot  be
converted to lower-case as-is:

```
header: { 'content-type': [ 'application/octet-stream' ],
  'content-disposition': [ 'form-data; name="file"; filename="tata"' ],
  'content-transfer-encoding': [ 'base64' ] }
```

If accepted, could this PR cause a version bump into npmjs.org?
