### PR TITLE
Report each file part's Content-Transport-Encoding as `encoding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ var Busboy = require('busboy');
 http.createServer(function(req, res) {
   if (req.method === 'POST') {
     var busboy = new Busboy({ headers: req.headers });
-    busboy.on('file', function(fieldname, file, filename) {
-      console.log('File [' + fieldname +']: filename: ' + filename);
+    busboy.on('file', function(fieldname, file, filename, encoding) {
+      console.log('File [' + fieldname +']: filename: ' + filename + ', encoding: ' + encoding);
       file.on('data', function(data) {
         console.log('File [' + fieldname +'] got ' + data.length + ' bytes');
       });
@@ -81,9 +81,9 @@ http.createServer(function(req, res) {
     var infiles = 0, outfiles = 0, done = false,
         busboy = new Busboy({ headers: req.headers });
     console.log('Start parsing form ...');
-    busboy.on('file', function(fieldname, file, filename) {
+    busboy.on('file', function(fieldname, file, filename, encoding) {
       ++infiles;
-      onFile(fieldname, file, filename, function() {
+      onFile(fieldname, file, filename, encoding, function() {
         ++outfiles;
         if (done)
           console.log(outfiles + '/' + infiles + ' parts written to disk');
@@ -105,7 +105,7 @@ http.createServer(function(req, res) {
   console.log('Listening for requests');
 });
 
-function onFile(fieldname, file, filename, next) {
+function onFile(fieldname, file, filename, encoding, next) {
   // or save at some other location
   var fstream = fs.createWriteStream(path.join(os.tmpDir(), path.basename(filename)));
   file.once('end', function() {

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -93,7 +93,7 @@ function Multipart(boy, limits, headers, parsedConType) {
 
         ++nfiles;
         var file = new FileStream();
-        boy.emit('file', fieldname, file, filename);
+        boy.emit('file', fieldname, file, filename, encoding);
 
         onData = function(data) {
           if ((nsize += data.length) > fileSizeLimit) {


### PR DESCRIPTION
Otherwise the user does not get a chance to apply a decoding filter.  The
alternative might be to directly handle the various encodings directly
within busboy.

I was able to test this against a (large) set of base64-encoded parts, without a binary error.  I used https://github.com/mazira/base64-stream to decode the ingress streams.  Note that this PR does not add a dependency to busboy, as the way to decode encoded parts is left to the developer.
