### PR TITLE
Default to UTF8 encoding for form fields rather than ISO-8859-1

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -1,4 +1,4 @@
-// TODO: 
+// TODO:
 //  * support 1 nested multipart level
 //    (see second multipart example here:
 //     http://www.w3.org/TR/html401/interact/forms.html#didx-multipartform-data)
@@ -64,7 +64,7 @@ function Multipart(boy, limits, headers, parsedConType) {
         }
       }
       if (charset === undefined)
-        charset = 'iso-8859-1';
+        charset = 'UTF8';
 
       if (header['content-disposition']) {
         parsed = utils.parseParams(header['content-disposition'][0]);

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -26,7 +26,7 @@ function UrlEncoded(boy, limits, headers, parsedConType) {
   }
 
   if (charset === undefined)
-    charset = 'ISO-8859-1';
+    charset = 'UTF8';
 
   this.decoder = new Decoder();
   this.charset = charset;


### PR DESCRIPTION
Not sure who still uses ISO-8859-1 these days. Better to default to the encoding nearly everybody uses these days.
