### PR TITLE
Fix file size limit to avoid crashing on node 0.8

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -155,7 +155,8 @@ function Multipart(boy, cfg) {
 
         onData = function(data) {
           if ((nsize += data.length) > fileSizeLimit) {
-            file.push(data.slice(0, (fileSizeLimit - nsize)));
+            if ((fileSizeLimit - nsize) >= 0)
+              file.push(data.slice(0, (fileSizeLimit - nsize)));
             file.emit('limit');
             part.removeAllListeners('data');
           } else if (!file.push(data))


### PR DESCRIPTION
On node 0.10, the file size limit works fine.  On 0.8, on the other hand:

```
buffer.js:559
  if (start > end) throw new Error('oob');
                         ^
Error: oob
    at Buffer.slice (buffer.js:559:26)
    at PartStream.parser.on.part.on.onData (/Users/avianflu/dev/blend/node_modules/busboy/lib/types/multipart.js:162:26)
    at PartStream.EventEmitter.emit (events.js:96:17)
    at readableAddChunk (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/readable-stream/lib/_stream_readable.js:179:16)
    at PartStream.Readable.push (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/readable-stream/lib/_stream_readable.js:146:10)
    at Dicer._oninfo (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/dicer/lib/Dicer.js:143:36)
    at SBMH.Dicer.setBoundary (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/dicer/lib/Dicer.js:92:10)
    at SBMH.EventEmitter.emit (events.js:106:17)
    at SBMH._sbmh_feed (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/dicer/node_modules/streamsearch/lib/sbmh.js:188:10)
    at SBMH.push (/Users/avianflu/dev/blend/node_modules/busboy/node_modules/dicer/node_modules/streamsearch/lib/sbmh.js:56:14)
```

The issue here is that in 0.10, node's `lib/buffer.js` sets the second argument to `Buffer.prototype.slice` to 0 if it exceeds the Buffer's size, whereas on 0.8, it just throws.

By checking for an appropriate value, and only adding the last slice if it fits, we avoid this problem.
