### PR TITLE
Issue with empty quoted string in header

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ function parseParams(str) {
     }
     tmp += str[i];
   }
-  if (tmp.length) {
+  if (tmp.length || tmp.length === 0) {
     if (charset) {
       tmp = decodeText(tmp.replace(RE_ENCODED, encodedReplacer),
                        'binary',


### PR DESCRIPTION
Can be problematic when some part of header is empty string in quotes - for example this problem

-----------------------------73161066925945
Content-Disposition: form-data; name="image"; filename=""
Content-Type: application/octet-stream
