### PR TITLE
Save all incoming files to disk example missing a require.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ http.createServer(function(req, res) {
 var http = require('http'),
     path = require('path'),
     os = require('os');
+    fs = require('fs');
 
 var Busboy = require('busboy');
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ http.createServer(function(req, res) {
 ```javascript
 var http = require('http'),
     path = require('path'),
-    os = require('os');
+    os = require('os'),
     fs = require('fs');
 
 var Busboy = require('busboy');


### PR DESCRIPTION
Adding one line. Code as-is doesn't run without the `fs` require.