### PR TITLE
add preservePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Busboy methods
 
     * **defCharset** - _string_ - Default character set to use when one isn't defined (Default: 'utf8').
 
+    * **preservePath** - _boolean_ - If paths in the multipart 'filename' field shall be preserved. (Default: false).
+
     * **limits** - _object_ - Various limits on incoming data. Valid properties are:
 
         * **fieldNameSize** - _integer_ - Max field name size (in bytes) (Default: 100 bytes).

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,13 +52,15 @@ Busboy.prototype.parseHeaders = function(headers) {
         parsedConType: parsed,
         highWaterMark: undefined,
         fileHwm: undefined,
-        defCharset: undefined
+        defCharset: undefined,
+        preservePath: false
       };
       if (this.opts.highWaterMark)
         cfg.highWaterMark = this.opts.highWaterMark;
       if (this.opts.fileHwm)
         cfg.fileHwm = this.opts.fileHwm;
       cfg.defCharset = this.opts.defCharset;
+      cfg.preservePath = this.opts.preservePath;
       this._parser = type(this, cfg);
       return;
     }

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -32,10 +32,11 @@ function Multipart(boy, cfg) {
       headers = cfg.headers,
       parsedConType = cfg.parsedConType || [],
       defCharset = cfg.defCharset || 'utf8',
+      preservePath = cfg.preservePath,
       fileopts = (typeof cfg.fileHwm === 'number'
                   ? { highWaterMark: cfg.fileHwm }
                   : {});
-  
+
   for (i = 0, len = parsedConType.length; i < len; ++i) {
     if (Array.isArray(parsedConType[i])
         && RE_BOUNDARY.test(parsedConType[i][0])) {
@@ -153,10 +154,13 @@ function Multipart(boy, cfg) {
         if (!RE_FIELD.test(parsed[0]))
           return skipPart(part);
         for (i = 0, len = parsed.length; i < len; ++i) {
-          if (RE_NAME.test(parsed[i][0]))
+          if (RE_NAME.test(parsed[i][0])) {
             fieldname = decodeText(parsed[i][1], 'binary', 'utf8');
-          else if (RE_FILENAME.test(parsed[i][0]))
-            filename = basename(decodeText(parsed[i][1], 'binary', 'utf8'));
+          } else if (RE_FILENAME.test(parsed[i][0])) {
+            filename = decodeText(parsed[i][1], 'binary', 'utf8');
+            if (!preservePath)
+              filename = basename(filename);
+          }
         }
       } else
         return skipPart(part);


### PR DESCRIPTION
This is needed for directory uploads:

https://wicg.github.io/directory-upload/proposal.html#h-form-submission

One could argue to make it the default behaviour, as I see no point in `basename`'ing the filename field, or is there one?