### PR TITLE
Added support for multipart/x-mixed-replace and tests

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -20,7 +20,7 @@ var RE_BOUNDARY = /^boundary$/i,
     RE_FILENAME = /^filename$/i,
     RE_NAME = /^name$/i;
 
-Multipart.detect = /^multipart\/form-data/i;
+Multipart.detect = /^multipart\/(form-data|x-mixed-replace)/i;
 function Multipart(boy, cfg) {
   if (!(this instanceof Multipart))
     return new Multipart(boy, cfg);
@@ -129,7 +129,8 @@ function Multipart(boy, cfg) {
           charset,
           encoding,
           filename,
-          nsize = 0;
+          nsize = 0,
+          isMixedReplace = parsedConType[0].toLowerCase() == "multipart/x-mixed-replace";
 
       if (header['content-type']) {
         parsed = parseParams(header['content-type'][0]);
@@ -162,7 +163,7 @@ function Multipart(boy, cfg) {
               filename = basename(filename);
           }
         }
-      } else
+      } else if (!isMixedReplace)
         return skipPart(part);
 
       if (header['content-transfer-encoding'])
@@ -172,7 +173,7 @@ function Multipart(boy, cfg) {
 
       var onData,
           onEnd;
-      if (contype === 'application/octet-stream' || filename !== undefined) {
+      if (contype === 'application/octet-stream' || filename !== undefined || isMixedReplace) {
         // file/binary field
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -41,6 +41,28 @@ var tests = [
     what: 'Fields and files'
   },
   { source: [
+      ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+       // content disposition is optional for x-mixed-replace
+       'Content-Type: image/jpeg',
+       '',
+       'data 1',
+       '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+       'Content-Disposition: form-data; name="data 2"; filename="data2.jpg"',
+       'Content-Type: image/jpeg',
+       '',
+       'data 2...',
+       '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+      ].join('\r\n')
+    ],
+    boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+    multipartType: 'x-mixed-replace',
+    expected: [
+      ['file', undefined, 6, 0, undefined, '7bit', 'image/jpeg'],
+      ['file', 'data 2', 9, 0, 'data2.jpg', '7bit', 'image/jpeg']
+    ],
+    what: 'Multipart replace'
+  },
+  { source: [
       ['------WebKitFormBoundaryTB2MiQ36fnSJlrhY',
        'Content-Disposition: form-data; name="cont"',
        '',
@@ -247,7 +269,7 @@ function next() {
         limits: v.limits,
         preservePath: v.preservePath,
         headers: {
-          'content-type': 'multipart/form-data; boundary=' + v.boundary
+          'content-type': 'multipart/' + (v.multipartType || 'form-data') + '; boundary=' + v.boundary
         }
       }),
       finishes = 0,


### PR DESCRIPTION
I wanted to parse an MJPEG stream from a webcam. The MJPEG format is already compatible with the busboy parser, but a couple of minor changes were required to Busboy's validation to allow it to accept these streams. 

* multipart parser now accepts `Content Type: multipart/x-mixed-replace`
* When parsing a `x-mixed-replace` stream, Content-Disposition is optional and every part is treated as a file regardless of content type (the behaviour for `multipart/form-data` streams is unchanged)
* added tests

If anyone is interested in using this patch before the pull request is merged, put this in your package.json:

```json
  "dependencies": {
    "busboy": "BernieSumption/busboy#5808c981fd1e25b3e35f1cd13d6231fa913fcec8"
  },
```