### PR TITLE
Pass "encoding" and "contype" to "field" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ http.createServer(function(req, res) {
         console.log('File [' + fieldname + '] Finished');
       });
     });
-    busboy.on('field', function(fieldname, val, fieldnameTruncated, valTruncated) {
+    busboy.on('field', function(fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) {
       console.log('Field [' + fieldname + ']: value: ' + inspect(val));
     });
     busboy.on('finish', function() {
@@ -175,7 +175,7 @@ Busboy (special) events
     * Note: if you listen for this event, you should always handle the `stream` no matter if you care about the file contents or not (e.g. you can simply just do `stream.resume();` if you want to discard the contents), otherwise the 'finish' event will never fire on the Busboy instance. However, if you don't care about **any** incoming files, you can simply not listen for the 'file' event at all and any/all files will be automatically and safely discarded (these discarded files do still count towards `files` and `parts` limits).
     * If a configured file size limit was reached, `stream` will both have a boolean property `truncated` (best checked at the end of the stream) and emit a 'limit' event to notify you when this happens.
 
-* **field**(< _string_ >fieldname, < _string_ >value, < _boolean_ >fieldnameTruncated, < _boolean_ >valueTruncated) - Emitted for each new non-file field found.
+* **field**(< _string_ >fieldname, < _string_ >value, < _boolean_ >fieldnameTruncated, < _boolean_ >valueTruncated, < _string_ >encoding, < _string_ >mimetype) - Emitted for each new non-file field found.
 
 * **partsLimit**() - Emitted when specified `parts` limit has been reached. No more 'file' or 'field' events will be emitted.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Busboy (special) events
     * Note: if you listen for this event, you should always handle the `stream` no matter if you care about the file contents or not (e.g. you can simply just do `stream.resume();` if you want to discard the contents), otherwise the 'finish' event will never fire on the Busboy instance. However, if you don't care about **any** incoming files, you can simply not listen for the 'file' event at all and any/all files will be automatically and safely discarded (these discarded files do still count towards `files` and `parts` limits).
     * If a configured file size limit was reached, `stream` will both have a boolean property `truncated` (best checked at the end of the stream) and emit a 'limit' event to notify you when this happens.
 
-* **field**(< _string_ >fieldname, < _string_ >value, < _boolean_ >fieldnameTruncated, < _boolean_ >valueTruncated, < _string_ >encoding, < _string_ >mimetype) - Emitted for each new non-file field found.
+* **field**(< _string_ >fieldname, < _string_ >value, < _boolean_ >fieldnameTruncated, < _boolean_ >valueTruncated, < _string_ >transferEncoding, < _string_ >mimeType) - Emitted for each new non-file field found.
 
 * **partsLimit**() - Emitted when specified `parts` limit has been reached. No more 'file' or 'field' events will be emitted.
 

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -254,7 +254,7 @@ function Multipart(boy, cfg) {
           curField = undefined;
           if (buffer.length)
             buffer = decodeText(buffer, 'binary', charset);
-          boy.emit('field', fieldname, buffer, false, truncated);
+          boy.emit('field', fieldname, buffer, false, truncated, encoding, contype);
           --nends;
           checkFinished();
         };

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -33,8 +33,8 @@ var tests = [
     ],
     boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
     expected: [
-      ['field', 'file_name_0', 'super alpha file', false, false],
-      ['field', 'file_name_1', 'super beta file', false, false],
+      ['field', 'file_name_0', 'super alpha file', false, false, '7bit', 'text/plain'],
+      ['field', 'file_name_1', 'super beta file', false, false, '7bit', 'text/plain'],
       ['file', 'upload_file_0', 1023, 0, '1k_a.dat', '7bit', 'application/octet-stream'],
       ['file', 'upload_file_1', 1023, 0, '1k_b.dat', '7bit', 'application/octet-stream']
     ],
@@ -58,9 +58,9 @@ var tests = [
     ],
     boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
     expected: [
-      ['field', 'cont', 'some random content', false, false],
-      ['field', 'pass', 'some random pass', false, false],
-      ['field', 'bit', '2', false, false]
+      ['field', 'cont', 'some random content', false, false, '7bit', 'text/plain'],
+      ['field', 'pass', 'some random pass', false, false, '7bit', 'text/plain'],
+      ['field', 'bit', '2', false, false, '7bit', 'text/plain']
     ],
     what: 'Fields only'
   },
@@ -90,7 +90,7 @@ var tests = [
       fieldSize: 5
     },
     expected: [
-      ['field', 'file_name_0', 'super', false, true],
+      ['field', 'file_name_0', 'super', false, true, '7bit', 'text/plain'],
       ['file', 'upload_file_0', 13, 2, '1k_a.dat', '7bit', 'application/octet-stream']
     ],
     what: 'Fields and files (limits)'
@@ -113,7 +113,7 @@ var tests = [
       files: 0
     },
     expected: [
-      ['field', 'file_name_0', 'super alpha file', false, false]
+      ['field', 'file_name_0', 'super alpha file', false, false, '7bit', 'text/plain']
     ],
     what: 'Fields and files (limits: 0 files)'
   },
@@ -141,8 +141,8 @@ var tests = [
     ],
     boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
     expected: [
-      ['field', 'file_name_0', 'super alpha file', false, false],
-      ['field', 'file_name_1', 'super beta file', false, false],
+      ['field', 'file_name_0', 'super alpha file', false, false, '7bit', 'text/plain'],
+      ['field', 'file_name_1', 'super beta file', false, false, '7bit', 'text/plain'],
     ],
     events: ['field'],
     what: 'Fields and (ignored) files'
@@ -217,7 +217,7 @@ var tests = [
     ],
     boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
     expected: [
-      ['field', 'cont', 'some random content', false, false]
+      ['field', 'cont', 'some random content', false, false, '7bit', 'text/plain']
     ],
     what: 'Empty content-type and empty content-disposition'
   },
@@ -235,6 +235,21 @@ var tests = [
     shouldError: 'Unexpected end of multipart data',
     what: 'Stopped mid-header'
   },
+  { source: [
+      ['------WebKitFormBoundaryTB2MiQ36fnSJlrhY',
+       'Content-Disposition: form-data; name="cont"',
+       'Content-Type: application/json',
+       '',
+       '{}',
+       '------WebKitFormBoundaryTB2MiQ36fnSJlrhY--',
+      ].join('\r\n')
+    ],
+    boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
+    expected: [
+      ['field', 'cont', '{}', false, false, '7bit', 'application/json']
+    ],
+    what: 'content-type for fields'
+  }
 ];
 
 function next() {
@@ -254,8 +269,8 @@ function next() {
       results = [];
 
   if (v.events === undefined || v.events.indexOf('field') > -1) {
-    busboy.on('field', function(key, val, keyTrunc, valTrunc) {
-      results.push(['field', key, val, keyTrunc, valTrunc]);
+    busboy.on('field', function(key, val, keyTrunc, valTrunc, encoding, contype) {
+      results.push(['field', key, val, keyTrunc, valTrunc, encoding, contype]);
     });
   }
   if (v.events === undefined || v.events.indexOf('file') > -1) {


### PR DESCRIPTION
This PR adds the arguments `contype` (Content-Type) and `encoding` to the `field` event, there are already passed to the `file` event.