### PR TITLE
Test incoming ASCII accented encoded strings

### DIFF
--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -13,7 +13,7 @@ var tests = [
       ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
        'Content-Disposition: form-data; name="file_name_0"',
        '',
-       'super alpha file',
+       new Buffer('súper alpha file', 'ascii'),
        '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
        'Content-Disposition: form-data; name="file_name_1"',
        '',
@@ -33,7 +33,7 @@ var tests = [
     ],
     boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
     expected: [
-      ['field', 'file_name_0', 'super alpha file', false, false, '7bit', 'text/plain'],
+      ['field', 'file_name_0', 'súper alpha file', false, false, '7bit', 'text/plain'],
       ['field', 'file_name_1', 'super beta file', false, false, '7bit', 'text/plain'],
       ['file', 'upload_file_0', 1023, 0, '1k_a.dat', '7bit', 'application/octet-stream'],
       ['file', 'upload_file_1', 1023, 0, '1k_b.dat', '7bit', 'application/octet-stream']


### PR DESCRIPTION
Searching for problems in my setup i'm in doubt if this test is the right one?

It seems in my ExpressJS setup, i'm receiving ASCII encoded requests (a given field with accents in it)

Dont know if its a problem with my setup, or busboy should handle it just fine?