### PR TITLE
Don't fire the 'finish' event twice when receiving an empty form.

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -80,6 +80,7 @@ function Multipart(boy, cfg) {
       curField,
       finished = false;
 
+  var empty = true;
   this._needDrain = false;
   this._pause = false;
   this._cb = undefined;
@@ -104,6 +105,7 @@ function Multipart(boy, cfg) {
       cb();
     }
   }).on('part', function onPart(part) {
+    empty = false;
     if (++self._nparts > partsLimit) {
       self.parser.removeListener('part', onPart);
       self.parser.on('part', skipPart);
@@ -275,6 +277,7 @@ function Multipart(boy, cfg) {
   }).on('error', function(err) {
     boy.emit('error', err);
   }).on('finish', function() {
+    if (empty) return;
     finished = true;
     checkFinished();
   });

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -294,8 +294,10 @@ Multipart.prototype.end = function() {
   var self = this;
   if (this._nparts === 0 && !self._boy._done) {
     process.nextTick(function() {
-      self._boy._done = true;
-      self._boy.emit('finish');
+      if (!self._boy._done) {
+        self._boy._done = true;
+        self._boy.emit('finish');
+      }
     });
   } else if (this.parser.writable)
     this.parser.end();

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -297,10 +297,8 @@ Multipart.prototype.end = function() {
   var self = this;
   if (this._nparts === 0 && !self._boy._done) {
     process.nextTick(function() {
-      if (!self._boy._done) {
-        self._boy._done = true;
-        self._boy.emit('finish');
-      }
+      self._boy._done = true;
+      self._boy.emit('finish');
     });
   } else if (this.parser.writable)
     this.parser.end();

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -249,6 +249,13 @@ var tests = [
       ['field', 'cont', '{}', false, false, '7bit', 'application/json']
     ],
     what: 'content-type for fields'
+  },
+  { source: [
+      '------WebKitFormBoundaryTB2MiQ36fnSJlrhY--\r\n'
+    ],
+    boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
+    expected: [],
+    what: 'empty form'
   }
 ];
 


### PR DESCRIPTION
This PR is thanks to https://github.com/mscdex/busboy/issues/110

Granted, this is a very unlikely corner case, but I could replicate it. I added a test and a small fix. It is crude, but at least the tests are passing now again ; ).