### PR TITLE
node 6 IncomingMessage events fix

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -49,7 +49,7 @@ function Multipart(boy, cfg) {
       finished = false;
       process.nextTick(function() {
         boy._done = true;
-        boy.emit('finish');
+        setImmediate(function () { boy.emit('finish') });
       });
     }
   }


### PR DESCRIPTION
Something seems to have changed between v4 and v6 around event ordering and piped streams, 

The following will behave differently between v4 and v6 (the end event is ignored in v6)

```js
var fs = require('fs')
var Busboy = require('busboy')
var http = require('http')

http.createServer((req, res) => {
  var busboy = new Busboy({ headers: req.headers })
  req.pipe(busboy)

  busboy.on('file', (field, file) => {
    var dest = fs.createWriteStream('/dev/null')
    file.pipe(dest)
  })

  req.on('end', () => console.log('req end')) // logs in v4, not in v6
  res.end(':)')
}).listen(8080)
```

Wrapping `boy.emit('finish')` in a `setImmediate` solves this, 
I haven't found any side effects to doing this, although that doesn't mean there may be some