### PR TITLE
fix: propagate file limit to busboy filesLimit

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -200,6 +200,9 @@ function Multipart(boy, cfg) {
             cb();
           }
         });
+        file.on('limit', function() {
+            boy.emit('filesLimit');
+        });
         file._read = function(n) {
           if (!self._pause)
             return;


### PR DESCRIPTION
max file sizes were not being propagated to the `filesLimit` event, this fixes that. Please review as I may be missing other details.