### PR TITLE
Logic changing: filesLimit fired when files count reached this limit.

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -173,15 +173,15 @@ function Multipart(boy, cfg) {
           onEnd;
       if (contype === 'application/octet-stream' || filename !== undefined) {
         // file/binary field
+        ++nfiles;
+
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {
             boy.hitFilesLimit = true;
             boy.emit('filesLimit');
-          }
-          return skipPart(part);
+          } else
+            return skipPart(part);
         }
-
-        ++nfiles;
 
         if (!boy._events.file) {
           self.parser._ignore();


### PR DESCRIPTION
This event fired, when files more than filesLimit. It must be fired when files count reached filesLimit. It's not an exception or something like this.
```
files: [0,1] ->
filesLimit = 2
```
Event will not fire.

Now it will be fired when files count = filesLimit