### PR TITLE
Don't decode params with encodings twice

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -154,9 +154,9 @@ function Multipart(boy, cfg) {
           return skipPart(part);
         for (i = 0, len = parsed.length; i < len; ++i) {
           if (RE_NAME.test(parsed[i][0])) {
-            fieldname = decodeText(parsed[i][1], 'binary', 'utf8');
+            fieldname = parsed[i][1];
           } else if (RE_FILENAME.test(parsed[i][0])) {
-            filename = decodeText(parsed[i][1], 'binary', 'utf8');
+            filename = parsed[i][1];
             if (!preservePath)
               filename = basename(filename);
           }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,6 +62,8 @@ function parseParams(str) {
                              charset);
           }
           charset = '';
+        } else if (tmp.length) {
+          tmp = decodeText(tmp, 'binary', 'utf8');
         }
         if (res[p] === undefined)
           res[p] = tmp;
@@ -79,6 +81,8 @@ function parseParams(str) {
     tmp = decodeText(tmp.replace(RE_ENCODED, encodedReplacer),
                      'binary',
                      charset);
+  } else if (tmp) {
+    tmp = decodeText(tmp, 'binary', 'utf8');
   }
 
   if (res[p] === undefined) {

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -222,6 +222,21 @@ var tests = [
     what: 'Empty content-type and empty content-disposition'
   },
   { source: [
+      ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+        'Content-Disposition: form-data; name="file"; filename*=utf-8\'\'n%C3%A4me.txt',
+       'Content-Type: application/octet-stream',
+       '',
+       'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+       '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+      ].join('\r\n')
+    ],
+    boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+    expected: [
+      ['file', 'file', 26, 0, 'näme.txt', '7bit', 'application/octet-stream']
+    ],
+    what: 'Unicode filenames'
+  },
+  { source: [
       ['--asdasdasdasd\r\n',
        'Content-Type: text/plain\r\n',
        'Content-Disposition: form-data; name="foo"\r\n',


### PR DESCRIPTION
busboy previously decoded encoding-tagged params twice. Once in the parseParams function, once in the multipart parser. This PR fixes that, by moving all decoding into the decodeParams function.

The alternative to this would be to "decode" into binary in the parseParams function, which would be a bit safer from a breakage pov, a bit worse from a performance pov.

I checked the instances where parseParams is called and I don't think this breaks anything since all of the other ones don't call decodeText afterwards, however this might now allow unicode to turn up in stuff like content-type (unintended, not sure what the spec says) and content-disposition (intended, it's what browsers require) params.