### PR TITLE
distinguish between `file` and `field`using content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Busboy (special) events
 -----------------------
 
 * **file**(< _string_ >fieldname, < _ReadableStream_ >stream, < _string_ >filename, < _string_ >transferEncoding, < _string_ >mimeType) - Emitted for each new file form field found. `transferEncoding` contains the 'Content-Transfer-Encoding' value for the file stream. `mimeType` contains the 'Content-Type' value for the file stream.
+    * The spec and other knowledges base are ambiguous about the difference between a normal form field and one that contains a file, so for our purposes, the difference between emitting a 'file' and a 'field' event is the presence of the 'Content-Type' 
+    value for the file stream. Parts without a 'Content-Type' will be treated as a 'field', with a default mimeType of `text/plain`.
     * Note: if you listen for this event, you should always handle the `stream` no matter if you care about the file contents or not (e.g. you can simply just do `stream.resume();` if you want to discard the contents), otherwise the 'finish' event will never fire on the Busboy instance. However, if you don't care about **any** incoming files, you can simply not listen for the 'file' event at all and any/all files will be automatically and safely discarded (these discarded files do still count towards `files` and `parts` limits).
     * If a configured file size limit was reached, `stream` will both have a boolean property `truncated` (best checked at the end of the stream) and emit a 'limit' event to notify you when this happens.
 

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -143,11 +143,6 @@ function Multipart(boy, cfg) {
         }
       }
 
-      if (contype === undefined)
-        contype = 'text/plain';
-      if (charset === undefined)
-        charset = defCharset;
-
       if (header['content-disposition']) {
         parsed = parseParams(header['content-disposition'][0]);
         if (!RE_FIELD.test(parsed[0]))
@@ -170,8 +165,17 @@ function Multipart(boy, cfg) {
         encoding = '7bit';
 
       var onData,
-          onEnd;
-      if (contype === 'application/octet-stream' || filename !== undefined) {
+          onEnd,
+          isFile = contype !== undefined || filename !== undefined
+
+      if (contype === undefined)
+        contype = 'text/plain';
+      if (charset === undefined)
+        charset = defCharset;
+      if (filename === undefined)
+        filename = ''
+
+      if (isFile) {
         // file/binary field
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -64,6 +64,22 @@ var tests = [
     ],
     what: 'Fields only'
   },
+  {
+    source: [
+      ['------WebKitFormBoundaryTB2MiQ36fnSJlrhY',
+       'Content-Disposition: form-data; name="file"',
+       'Content-Type: text/plain',
+       '',
+       'this is a file with no name',
+       '------WebKitFormBoundaryTB2MiQ36fnSJlrhY--'
+      ].join('\r\n')
+    ],
+    boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
+    expected: [
+      ['file', 'file', 27, 0, '', '7bit', 'text/plain']
+    ],
+    what: "File without a filename attribute"
+  },
   { source: [
       ''
     ],
@@ -234,21 +250,6 @@ var tests = [
     expected: [],
     shouldError: 'Unexpected end of multipart data',
     what: 'Stopped mid-header'
-  },
-  { source: [
-      ['------WebKitFormBoundaryTB2MiQ36fnSJlrhY',
-       'Content-Disposition: form-data; name="cont"',
-       'Content-Type: application/json',
-       '',
-       '{}',
-       '------WebKitFormBoundaryTB2MiQ36fnSJlrhY--',
-      ].join('\r\n')
-    ],
-    boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
-    expected: [
-      ['field', 'cont', '{}', false, false, '7bit', 'application/json']
-    ],
-    what: 'content-type for fields'
   },
   { source: [
       '------WebKitFormBoundaryTB2MiQ36fnSJlrhY--\r\n'


### PR DESCRIPTION
Previously, busboy decided if a part of a request was a file based on the presence of a `filename` in the part's content disposition, or if the content-type was `application/octet-stream`. This PR changes that, and now busboy decides based on the presence of the part's content-type header, no matter what mime type it is.

the driving force behind this is that the `filename` attribute in the part's content-disposition is optional, not required. we are in a situation where a legacy api is posting a file without a filename, which is still a valid form-data request. The spec for `multipart/form-data` isn't very clear about the difference between a normal form field and one that contains a file, so we decided for our uses to draw the line at the presence of the `content-type` header.

This means that all parts that trigger a `field` event will have the default content-type of `text/plain`, and if users rely on specific content-types for their fields, (like in #106) those will be treated as `file` events instead.

What are your thoughts? If you decide that this course isn't what you want for the library, then that's okay with us - this just is a bit more clear on what's a file and what's not.