### PR TITLE
Ignore filename "blob" when handling files

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -171,7 +171,7 @@ function Multipart(boy, cfg) {
 
       var onData,
           onEnd;
-      if (contype === 'application/octet-stream' || filename !== undefined) {
+      if (contype === 'application/octet-stream' || (filename !== undefined && filename !== 'blob')) {
         // file/binary field
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {


### PR DESCRIPTION
Chrome, Firefox and I guess more browsers set a default filename for "blob" if you pass a new Blob field into a form data. I couldn't figure it out to remove this filename, it is also specified here:
https://developer.mozilla.org/en-US/docs/Web/API/FormData/append

e.g.
const form = new FormData();
form.append('jsonStuff', new Blob([JSON.stringify({a: 1})], {type: 'application/json'});

results into:
------WebKitFormBoundaryeFyAvRTAPR4MqtxM
Content-Disposition: form-data; name="requiredFields"; filename="blob"
Content-Type: application/json

The most "common" way would be ignoring "blob", I could also think about a different workaround where we define a filename that gets ignored to ensure that there is no backward compatibility break. (e.g. filename=BUSBOY_IGNORE_FILE or whatever ;))

I'm using "multer" node js library, where this issue occurs.

regards
Simon