### PR TITLE
Conform with SI units

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -59,7 +59,7 @@ function Multipart(boy, cfg) {
 
   var fieldSizeLimit = (limits && typeof limits.fieldSize === 'number'
                         ? limits.fieldSize
-                        : 1 * 1024 * 1024),
+                        : 1 * 1000 * 1000),
       fileSizeLimit = (limits && typeof limits.fileSize === 'number'
                        ? limits.fileSize
                        : Infinity),


### PR DESCRIPTION
Readme states that:
"fieldSize - integer - Max field value size (in bytes) (Default: 1MB)"

Or nowadays most OS filesystems respect the SI standard for files size so 1 MB = 1 * 1000 * 1000

Source example: https://wiki.ubuntu.com/UnitsPolicy

If you keep 1 * 1024 * 1024 you should modify the readme MB to MiB to avoid confusion