### PR TITLE
Error on non-number limit rather than ignoring

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -12,7 +12,8 @@ var Dicer = require('dicer');
 
 var parseParams = require('../utils').parseParams,
     decodeText = require('../utils').decodeText,
-    basename = require('../utils').basename;
+    basename = require('../utils').basename,
+    getLimit = require('../utils').getLimit;
 
 var RE_BOUNDARY = /^boundary$/i,
     RE_FIELD = /^form-data$/i,
@@ -57,21 +58,11 @@ function Multipart(boy, cfg) {
   if (typeof boundary !== 'string')
     throw new Error('Multipart: Boundary not found');
 
-  var fieldSizeLimit = (limits && typeof limits.fieldSize === 'number'
-                        ? limits.fieldSize
-                        : 1 * 1024 * 1024),
-      fileSizeLimit = (limits && typeof limits.fileSize === 'number'
-                       ? limits.fileSize
-                       : Infinity),
-      filesLimit = (limits && typeof limits.files === 'number'
-                    ? limits.files
-                    : Infinity),
-      fieldsLimit = (limits && typeof limits.fields === 'number'
-                     ? limits.fields
-                     : Infinity),
-      partsLimit = (limits && typeof limits.parts === 'number'
-                    ? limits.parts
-                    : Infinity);
+  var fieldSizeLimit = getLimit(limits, 'fieldSize', 1 * 1024 * 1024),
+      fileSizeLimit = getLimit(limits, 'fileSize', Infinity),
+      filesLimit = getLimit(limits, 'files', Infinity),
+      fieldsLimit = getLimit(limits, 'fields', Infinity),
+      partsLimit = getLimit(limits, 'parts', Infinity);
 
   var nfiles = 0,
       nfields = 0,

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -1,5 +1,6 @@
 var Decoder = require('../utils').Decoder,
-    decodeText = require('../utils').decodeText;
+    decodeText = require('../utils').decodeText,
+    getLimit = require('../utils').getLimit;
 
 var RE_CHARSET = /^charset$/i;
 
@@ -12,15 +13,9 @@ function UrlEncoded(boy, cfg) {
       parsedConType = cfg.parsedConType;
   this.boy = boy;
 
-  this.fieldSizeLimit = (limits && typeof limits.fieldSize === 'number'
-                         ? limits.fieldSize
-                         : 1 * 1024 * 1024);
-  this.fieldNameSizeLimit = (limits && typeof limits.fieldNameSize === 'number'
-                             ? limits.fieldNameSize
-                             : 100);
-  this.fieldsLimit = (limits && typeof limits.fields === 'number'
-                      ? limits.fields
-                      : Infinity);
+  this.fieldSizeLimit = getLimit(limits, 'fieldSize', 1 * 1024 * 1024);
+  this.fieldNameSizeLimit = getLimit(limits, 'fieldNameSize', 100);
+  this.fieldsLimit = getLimit(limits, 'fields', Infinity);
 
   var charset;
   for (var i = 0, len = parsedConType.length; i < len; ++i) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,3 +170,18 @@ function basename(path) {
   return (path === '..' || path === '.' ? '' : path);
 }
 exports.basename = basename;
+
+
+function getLimit(limits, name, defaultLimit) {
+  if (!limits) return defaultLimit;
+
+  var limit = limits[name];
+  if (limit === undefined) return defaultLimit;
+
+  if (typeof limit !== 'number') {
+    throw new Error('busboy: limit ' + name + ' is not a number');
+  }
+
+  return limit;
+}
+exports.getLimit = getLimit;

--- a/test/test-utils-get-limit.js
+++ b/test/test-utils-get-limit.js
@@ -1,0 +1,16 @@
+var getLimit = require('../lib/utils').getLimit;
+
+var assert = require('assert').strict;
+
+assert.deepStrictEqual(getLimit(undefined, 'fieldSize', 1), 1);
+assert.deepStrictEqual(getLimit(undefined, 'fileSize', Infinity), Infinity);
+
+assert.deepStrictEqual(getLimit({}, 'fieldSize', 1), 1);
+assert.deepStrictEqual(getLimit({}, 'fileSize', Infinity), Infinity);
+
+assert.deepStrictEqual(getLimit({ fieldSize: 0 }, 'fieldSize', 1), 0);
+assert.deepStrictEqual(getLimit({ fileSize: 2 }, 'fileSize', 1), 2);
+
+assert.throws(function() {
+  getLimit({ fieldSize: '1' }, 'fieldSize', 1);
+}, { message: 'busboy: limit fieldSize is not a number' });


### PR DESCRIPTION
Currently if you set a configuration limit, such as `fileSize`, to a string, the default is silently used instead.

Clearly passing a string is wrong (mea culpa!), but it is an easy mistake to make, because these limits are often set from environment variables. The result is that `fileSize` gets set to its default value of `Infinity` rather than the intended limit in the env var, leaving the app with no limit on the size of the files it would try to process.

A few seconds of searching on GitHub reveals I am not alone in making this blunder:
- https://github.com/duyk16/fullstack-app-js/blob/46019e3c541a6ea61b8c7c8fec4bbc17611ad499/server/middlewares/upload.middlerware.js#L21-L26
- https://github.com/templetonpr/fcc-file-metadata-microservice/blob/f2f9c7a8d8d1126f8a634329ee5d0bb29b5d471d/server.js#L7
- https://github.com/merq-rodriguez/geoprogram/blob/df8127fa74c420f4400161dc468f4ec2f93f4e4d/src/common/config/multer.config.ts#L18
- https://github.com/b0939261761/coffee-print-server/blob/ba46c933ebaccdc728759bd3feeaa824ac36bd7e/routes/galleries.js#L66-L70

In my case, I had an app using [node-config](https://github.com/lorenwest/node-config):
```
limits: {
    files: 1,
    fileSize: config.get('maxFileUploadSize')
  }
```
which was OK when the default limit came from a JSON config file and was a number. But then one day I added an environment variable override, so `config.get` returned a string, which caused `fileSize` to actually get the default value of `Infinity`.

Here I've proposed making it an error to do this. Doing so without a lot of repetition required making a helper function to get the limit from config and validate it.

I think this would be considered a breaking change. Some apps that are currently running insecurely without upload limits would instead crash on boot. That's not great either, of course, but I think on balance it would be better to fail fast rather than to run silently in an unsafe way.