### PR TITLE
Changed Buffer creation in TextEncoder

### DIFF
--- a/deps/encoding/encoding.js
+++ b/deps/encoding/encoding.js
@@ -38,6 +38,19 @@
 */
 
 //
+// Helper variables
+//
+
+/**
+ * Determines if the current node version requires the modern Buffer implementation
+ **/
+var isModernBuffer = (
+   typeof Buffer.alloc === 'function' &&
+   typeof Buffer.allocUnsafe === 'function' &&
+   typeof Buffer.from === 'function'
+ );
+  
+//
 // Utilities
 //
 
@@ -1008,13 +1021,7 @@ TextEncoder.prototype = {
       } while (last_byte !== EOF_byte);
       this._encoder = null;
     }
-    
-    var isModernBuffer = (
-      typeof Buffer.alloc === 'function' &&
-      typeof Buffer.allocUnsafe === 'function' &&
-      typeof Buffer.from === 'function'
-    );
-    
+     
     return isModernBuffer ? Buffer.from(bytes) : new Buffer(bytes);
   }
 };

--- a/deps/encoding/encoding.js
+++ b/deps/encoding/encoding.js
@@ -986,7 +986,6 @@ TextEncoder.prototype = {
    * @param {{stream: boolean}=} options
    */
   encode: function encode(opt_string, options) {
-
     opt_string = opt_string ? String(opt_string) : '';
     options = Object(options);
     // TODO: any options?

--- a/deps/encoding/encoding.js
+++ b/deps/encoding/encoding.js
@@ -986,6 +986,7 @@ TextEncoder.prototype = {
    * @param {{stream: boolean}=} options
    */
   encode: function encode(opt_string, options) {
+
     opt_string = opt_string ? String(opt_string) : '';
     options = Object(options);
     // TODO: any options?
@@ -1008,7 +1009,14 @@ TextEncoder.prototype = {
       } while (last_byte !== EOF_byte);
       this._encoder = null;
     }
-    return new Buffer(bytes);
+    
+    var isModernBuffer = (
+      typeof Buffer.alloc === 'function' &&
+      typeof Buffer.allocUnsafe === 'function' &&
+      typeof Buffer.from === 'function'
+    );
+    
+    return isModernBuffer ? Buffer.from(bytes) : new Buffer(bytes);
   }
 };
 


### PR DESCRIPTION
Buffer creation is changed in newer node versions. 
The `new Buffer(...)` constructor style is deprecated, and gives an error.

Modified TextEncoder.prototype in deps/encoding/encoding.js to support both the old constructor style as the new Buffer.from style