### PR TITLE
Do not assume text/plain content-type when content-type is missing.

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -144,7 +144,11 @@ function Multipart(boy, cfg) {
       }
 
       if (contype === undefined)
-        contype = 'text/plain';
+        // As per rfc-7231:
+        // > If a Content-Type header field is not present, the recipient
+        // > MAY either assume a media type of "application/octet-stream"
+        // > or examine the data to determine its type.
+        contype = 'application/octet-stream';
       if (charset === undefined)
         charset = defCharset;
 


### PR DESCRIPTION
In order to comply with RFC-7231:

>  A sender that generates a message containing a payload body SHOULD
>  generate a Content-Type header field in that message unless the
>  intended media type of the enclosed representation is unknown to the
>  sender.  If a Content-Type header field is not present, the recipient
>  MAY either assume a media type of "application/octet-stream"
>  ([RFC2046], Section 4.5.1) or examine the data to determine its type.

Assuming text/plain is problematic for example when trying to decide whether to attempt file-type detection, since a consumer can not distinguish between an explicit text/plain or an unknown content-type.

We have the option of not setting the content-type or using octet-stream, either seems fine to me but I have chosen the latter since it seems closer to the current implementation

Signed-off-by: Silas Davis <silas@monax.io>