### PR TITLE
Fix #121 : require explicitly supported content types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const { readdirSync } = require('fs');
-const { join } = require('path');
-
 const { parseContentType } = require('./utils.js');
 
 function getInstance(cfg) {
@@ -37,14 +34,12 @@ function getInstance(cfg) {
   throw new Error(`Unsupported content type: ${headers['content-type']}`);
 }
 
-const TYPES = [];
-for (const file of readdirSync(join(__dirname, 'types'))) {
-  if (/\.js$/i.test(file)) {
-    const type = require(`./types/${file}`);
-    if (type && typeof type.detect === 'function')
-      TYPES.push(type);
-  }
-}
+// Note: types are explicitly listed here for easier bundling
+// See: https://github.com/mscdex/busboy/issues/121
+const TYPES = [
+  require('./types/multipart'),
+  require('./types/urlencoded'),
+].filter(function(typemod) { return typeof typemod.detect === 'function'; });
 
 module.exports = (cfg) => {
   if (typeof cfg !== 'object' || cfg === null)


### PR DESCRIPTION
Make it easier to bundle `busboy`.
Original PR: https://github.com/mscdex/busboy/pull/122