### PR TITLE
Refactor license information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "engines": { "node": ">=10.16.0" },
   "keywords": [ "uploads", "forms", "multipart", "form-data" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/busboy/raw/master/LICENSE" } ],
+  "license": "MIT",
   "repository": { "type": "git", "url": "http://github.com/mscdex/busboy.git" }
 }


### PR DESCRIPTION
Refactored the deprecated style with key licenses in package.json
see https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license