### PR TITLE
feat: web idl like features

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -172,10 +172,15 @@ class HeaderParser {
 }
 
 class FileStream extends Readable {
-  constructor(opts, owner) {
+  constructor(opts, owner, info) {
     super(opts);
     this.truncated = false;
     this._readcb = null;
+
+    // Web File IDL similarities
+    this.name = info.filename;
+    this.type = info.mimeType;
+
     this.once('end', () => {
       // We need to make sure that we call any outstanding _writecb() that is
       // associated with this file so that processing of the rest of the form
@@ -191,12 +196,73 @@ class FileStream extends Readable {
       }
     });
   }
+
   _read(n) {
     const cb = this._readcb;
     if (cb) {
       this._readcb = null;
       cb();
     }
+  }
+
+  async text() {
+    const textDecoder = new TextDecoder();
+    let result = '';
+    for await (const chunk of this) {
+      result += textDecoder.decode(chunk, { stream: true });
+    }
+    result += textDecoder.decode(); // flush
+    return result;
+  }
+
+  /**
+   * Returns a promise that resolves with the "safe" ArrayBuffer
+   */
+  async arrayBuffer () {
+    const chunks = [];
+    let size = 0;
+
+    for await (const chunk of this) {
+      chunks.push(chunk);
+      size += chunk.length;
+    }
+
+    const view = new Uint8Array(size);
+    size = 0;
+    for (const chunk of chunks) {
+      view.set(chunk, size);
+      size += chunk.length;
+    }
+
+    return view.buffer;
+  }
+
+  /**
+   * Consumes the stream and returns a promise that resolves to a Blob
+   *
+   * @param {typeof Blob} Blob Optional Blob class to use for creating the Blob.
+   * @since (NodeJS v18.0.0)
+   */
+  async blob(Blob = globalThis.Blob) {
+    const chunks = [];
+
+    for await (const chunk of this) {
+      chunks.push(new Blob([chunk]));
+    }
+
+    return new Blob(chunks, { type: this.type });
+  }
+
+  async file(File = globalThis.File) {
+    return new File([await this.blob()], this.name, { type: this.type });
+  }
+
+  /**
+   * Converts the stream to a web stream
+   * @since 17.0.0
+   */
+  stream() {
+    return Readable.toWeb(this)
   }
 }
 
@@ -353,15 +419,16 @@ class Multipart extends Writable {
         }
 
         fileSize = 0;
-        this._fileStream = new FileStream(fileOpts, this);
+        const info = { filename,
+          encoding: partEncoding,
+          mimeType: partType }
+        this._fileStream = new FileStream(fileOpts, this, info);
         ++this._fileEndsLeft;
         this.emit(
           'file',
           partName,
           this._fileStream,
-          { filename,
-            encoding: partEncoding,
-            mimeType: partType }
+          info
         );
       } else {
         // Non-file


### PR DESCRIPTION
undici is considering using busboy as a mean to decode multipart formdata payloads as a way to resolve `body.formData()` to life, accepting this changes would help us at undici and node-fetch bringing `await body.formData()` to life while also closing #228

I have made the FileStream behave almost the same way a standard `window.File` object to make working with files much more easier, by giving the `FileStream` some extra features.

- `FileStream.prototype.name` to resemble what web `File.prototype.name` idl class looks like
- `FileStream.prototype.type` to resemble what web `File.prototype.type` idl class looks like
- `FileStream.prototype.stream()` to resemble what web `File.prototype.stream()` idl class looks like
- `FileStream.prototype.text()` to resemble what web `File.prototype.stream()` idl class looks like<br> it will decode the file pretty much the same way as `response.text()` & `file.text()` (by also removing BOM)
- `FileStream.prototype.blob( optional_blob_class )` returns a promise solving to a blob \w type
- `FileStream.prototype.file( optional_file_class )` returns a promise solving to a file \w type & filename

with this we can now do something like:

```js
bb.on('file', async (name, fileStream) => {
  await fileStream.text()
  await fileStream.arrayBuffer()
  await fileStream.blob( optionalBlobClass )
  await fileStream.file( optionalFileClass )
  fileStream.stream() // returns a web stream
  fileStream.name // the file name
  fileStream.type // the mime type
})
```

having this features would also help us creating a FormData much in a much more easier way.