### PR TITLE
Allow passing function to limits.fileSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ http.createServer((req, res) => {
 
         * **fields** - _integer_ - Max number of non-file fields. **Default:** `Infinity`.
 
-        * **fileSize** - _integer_ - For multipart forms, the max file size (in bytes). **Default:** `Infinity`.
+        * **fileSize** - _integer_, _function_ - For multipart forms, the max file size (in bytes). **Default:** `Infinity`.
 
         * **files** - _integer_ - For multipart forms, the max number of file fields. **Default:** `Infinity`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ function getInstance(cfg) {
       continue;
 
     const instanceCfg = {
+      req: cfg.req,
       limits: cfg.limits,
       headers,
       conType,

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -218,6 +218,18 @@ function nullDecoder(val, hint) {
   return val;
 }
 
+function getFileSizeLimit(req, limits) {
+  if (limits) {
+    if (typeof limits.fileSize === 'number') {
+      return limits.fileSize;
+    } else if (typeof limits.fileSize === 'function') {
+      return limits.fileSize(req);
+    }
+  }
+
+  return Infinity;
+}
+
 class Multipart extends Writable {
   constructor(cfg) {
     const streamOpts = {
@@ -251,9 +263,7 @@ class Multipart extends Writable {
     const fieldSizeLimit = (limits && typeof limits.fieldSize === 'number'
                             ? limits.fieldSize
                             : 1 * 1024 * 1024);
-    const fileSizeLimit = (limits && typeof limits.fileSize === 'number'
-                           ? limits.fileSize
-                           : Infinity);
+    const fileSizeLimit = getFileSizeLimit(cfg.req, limits);
     const filesLimit = (limits && typeof limits.files === 'number'
                         ? limits.files
                         : Infinity);


### PR DESCRIPTION
```js
limits: {
  fileSize: (req) => {
    return req.storage.maxFileSize;
  }
}
```