### PR TITLE
package: set `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "A streaming parser for HTML form data for node.js",
   "main": "./lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "streamsearch": "^1.1.0"
   },


### PR DESCRIPTION
This ensures only the files necessary at runtime are published to npm (in this case, the `lib` directory)

You can verify by running `npm pack`.

See docs: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files