### PR TITLE
remove use of `this` with TextDecoder

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -464,7 +464,7 @@ const decoders = {
     if (typeof data === 'string')
       data = Buffer.from(data, 'latin1');
     try {
-      const decoder = new TextDecoder(this);
+      const decoder = new TextDecoder();
       return decoder.decode(data);
     } catch {}
   },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -413,7 +413,7 @@ function getDecoder(charset) {
           charset = charset.toLowerCase();
           continue;
         }
-        return decoders.other.bind(charset);
+        return decoders.other(charset);
     }
   }
 }
@@ -458,13 +458,13 @@ const decoders = {
     return data.base64Slice(0, data.length);
   },
 
-  other: (data, hint) => {
+  other: (charset) => (data, hint) => {
     if (data.length === 0)
       return '';
     if (typeof data === 'string')
       data = Buffer.from(data, 'latin1');
     try {
-      const decoder = new TextDecoder();
+      const decoder = new TextDecoder(charset);
       return decoder.decode(data);
     } catch {}
   },


### PR DESCRIPTION
this fixes issues with ESM bundlers such as rollup
