### PR TITLE
Support file input as optional

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -315,7 +315,7 @@ class Multipart extends Writable {
 
         if (disp.params['filename*'])
           filename = disp.params['filename*'];
-        else if (disp.params.filename)
+        else if (disp.params.filename !== undefined)
           filename = disp.params.filename;
 
         if (filename !== undefined && !preservePath)

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -867,6 +867,32 @@ const tests = [
     ],
     what: 'Empty part'
   },
+    { source: [
+            ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+                'Content-Disposition: form-data; '
+                + 'name="upload_file_0"; filename=""',
+                'Content-Type: application/octet-stream',
+                '',
+                '',
+                '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--',
+            ].join('\r\n')
+        ],
+        boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+        expected: [
+            { type: 'file',
+                name: 'upload_file_0',
+                data: new Buffer.from(''),
+                info: {
+                    filename: '',
+                    encoding: '7bit',
+                    mimeType: 'application/octet-stream',
+                },
+                limited: false,
+            }
+        ],
+        events: ['file'],
+        what: 'Optional file'
+    }
 ];
 
 for (const test of tests) {


### PR DESCRIPTION
When the file input in a form doesn't have any file selected, busboy will fire 'field' event instead of 'file', which leads this field have an empty string value.